### PR TITLE
fix device object refs missing extra "device"

### DIFF
--- a/package/zone.js
+++ b/package/zone.js
@@ -19,12 +19,12 @@ function setZone(discovery, req, res) {
         return;
     }
 
-    if (device.ip == slaveDevice.ip) {
+    if (device.device.ip == slaveDevice.device.ip) {
         res.json({message:'Master and Slave cannot be the same device.'});
         return;
     }
 
-    var members = [slaveDevice.txtRecord.MAC];
+    var members = [slaveDevice.device.txtRecord.MAC];
 
     //TODO: support for multiple members
     device.setZone(members, function(json, info) {
@@ -47,12 +47,12 @@ function addZoneSlave(discovery, req, res) {
         return;
     }
 
-    if (device.ip == slaveDevice.ip) {
+    if (device.device.ip == slaveDevice.device.ip) {
         res.json({message:'Master and Slave cannot be the same device.'});
         return;
     }
 
-    var members = [slaveDevice.txtRecord.MAC];
+    var members = [slaveDevice.device.txtRecord.MAC];
 
     //TODO: support for multiple members
     device.addZoneSlave(members, function(json, info) {
@@ -75,12 +75,12 @@ function removeZoneSlave(discovery, req, res) {
         return;
     }
 
-    if (device.ip == slaveDevice.ip) {
+    if (device.device.ip == slaveDevice.device.ip) {
         res.json({message:'Master and Slave cannot be the same device.'});
         return;
     }
 
-    var members = [slaveDevice.txtRecord.MAC];
+    var members = [slaveDevice.device.txtRecord.MAC];
 
     //TODO: support for multiple members
     device.removeZoneSlave(members, function(json, info) {


### PR DESCRIPTION
Zones wasn't working; I did some quick digging and saw that the devices were missing and extra "device" reference. each device has device, name, and socket fields, and the ips are children of the device field.