### PR TITLE
Fix select API call by adding missing property

### DIFF
--- a/api.js
+++ b/api.js
@@ -94,12 +94,12 @@ SoundTouchAPI.prototype.setVolume = function(volume, handler) {
 };
 
 
-SoundTouchAPI.prototype.select = function(source, sourceAccount, location, handler) {
+SoundTouchAPI.prototype.select = function(source, type, sourceAccount, location, handler) {
     if (source == undefined) {
         throw new Error("Source is not optional, provide a source from the SOURCES list.");
     }
 
-    var data = '<ContentItem source="' + source + '" sourceAccount="' + sourceAccount + '" location="' + location + '">' +
+    var data = '<ContentItem source="' + source + '" type="' + type + '" sourceAccount="' + sourceAccount + '" location="' + location + '">' +
         '<itemName>' + 'Select using API' + '</itemName>' +
         '</ContentItem>';
 


### PR DESCRIPTION
Fix #3 
You'll find the type property in the updated dev tool here http://bosedevs.com/#!/SoundTouch_Control_API_Explorer/post_select