### PR TITLE
episodeSelector functionality added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,7 @@ build/Release
 node_modules
 
 .idea
+
+# life configuration data
+collectorSettings.json
+dataStore

--- a/README.md
+++ b/README.md
@@ -7,11 +7,25 @@ npm install soundtouch --save
 ```
 Start the server to make use of the HTTP API
 ```bash
-git clone https://github.com/CONNCTED/SoundTouch-NodeJS.git
+git clone https://github.com/thevassiliou/SoundTouch-NodeJS.git
 cd SoundTOuch-NodeJS
 npm install
 node server.js
 ```
 
 ## Usage
-TODO
+Besides the provisioning of the Soundtouch API to control a soundtouch system ([guide] (https://github.com/Adeptive/SoundTouch-NodeJS/wiki) it offers the function to randomly select an album from a predfined set of albums and store it in a given preset. 
+
+### Using Episode Selector
+http://127.0.0.1:5006/auto/episodeSelector/:presetKey?
+http://127.0.0.1:5006/auto/getAllEpisodes
+
+### episodeSelector
+with '''auto/episodeSelector/:presetKey?''' you can instruct the system to store a randomly selected on a given preset, or #6 if none is given.
+The dataset from which the episodes are selected is stored in the '''dataStore/libraryContent.json'''. 
+
+The content of this database can be retrieved via '''auto/getAllEpisodes'''. 
+
+### episodeCollector
+The database of episodes can be filled via the episodeCollector. 
+You start the episodeCollector vial '''node episodeCollector.js''' The episodeCollector listens on changes on the given device (in collectorSetting.json (example in collectorSettingsExample.json)). EpisodeCollector stores in the database every album that will be started on the device, and that serves as the dataset for '''episodeSelector'''

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Besides the provisioning of the Soundtouch API to control a soundtouch system ([
 
 ### Using Episode Selector
 http://127.0.0.1:5006/auto/episodeSelector/:presetKey?
+
 http://127.0.0.1:5006/auto/getAllEpisodes
 
 ### episodeSelector

--- a/api.js
+++ b/api.js
@@ -180,7 +180,19 @@ SoundTouchAPI.prototype.powerOff = function(handler) {
  * @param handler function (required)
  */
 SoundTouchAPI.prototype.setPreset = function(presetNumber, handler) {
-    this.pressKey("PRESET_" + presetNumber, handler);
+  var key = "PRESET_" + presetNumber;
+
+  var press = "<key state=\"press\" sender=\"Gabbo\">" + key + "</key>";
+  var release = "<key state=\"release\" sender=\"Gabbo\">" + key + "</key>";
+
+  var api = this;
+
+  api._setForDevice("key", press, function(json) {
+      // Because of lack of documentation from Bose using 1sec to make sure
+      var waitTill = new Date(new Date().getTime() + 2 * 1000);
+      while (waitTill > new Date()) {}
+      api._setForDevice("key", release, handler);
+  });
 };
 
 SoundTouchAPI.prototype.pressKey = function(key, handler) {
@@ -190,9 +202,6 @@ SoundTouchAPI.prototype.pressKey = function(key, handler) {
     var api = this;
 
     api._setForDevice("key", press, function(json) {
-        // Because of lack of documentation from Bose using 1sec to make sure
-        var waitTill = new Date(new Date().getTime() + 1 * 1000);
-        while (waitTill > new Date()) {}
         api._setForDevice("key", release, handler);
     });
 };

--- a/api.js
+++ b/api.js
@@ -59,12 +59,12 @@ SoundTouchAPI.prototype.getInfo = function(handler) {
 };
 
 SoundTouchAPI.prototype.isAlive = function(handler) {
-    this.getNowPlaying(function(json){
+    this.getNowPlaying(function(json) {
         if (json == undefined) {
             handler(false);
             return;
         }
-        var isAlive =  json.nowPlaying.source != SOURCES.STANDBY;
+        var isAlive = json.nowPlaying.source != SOURCES.STANDBY;
         if (isAlive) {
             isAlive = json.nowPlaying.playStatus == 'PLAY_STATE';
         }
@@ -73,12 +73,12 @@ SoundTouchAPI.prototype.isAlive = function(handler) {
 };
 
 SoundTouchAPI.prototype.isPoweredOn = function(handler) {
-    this.getNowPlaying(function(json){
+    this.getNowPlaying(function(json) {
         if (json == undefined) {
             handler(false);
             return;
         }
-        var isAlive =  json.nowPlaying.source != SOURCES.STANDBY;
+        var isAlive = json.nowPlaying.source != SOURCES.STANDBY;
         handler(isAlive);
     });
 };
@@ -99,7 +99,8 @@ SoundTouchAPI.prototype.select = function(source, type, sourceAccount, location,
         throw new Error("Source is not optional, provide a source from the SOURCES list.");
     }
 
-    var data = '<ContentItem source="' + source + '" type="' + type + '" sourceAccount="' + sourceAccount + '" location="' + location + '">' +
+    var data = '<ContentItem source="' + source + '" type="' + type + '" sourceAccount="' + sourceAccount +
+        '" location="' + location + '">' +
         '<itemName>' + 'Select using API' + '</itemName>' +
         '</ContentItem>';
 
@@ -189,6 +190,9 @@ SoundTouchAPI.prototype.pressKey = function(key, handler) {
     var api = this;
 
     api._setForDevice("key", press, function(json) {
+        // Because of lack of documentation from Bose using 1sec to make sure
+        var waitTill = new Date(new Date().getTime() + 1 * 1000);
+        while (waitTill > new Date()) {}
         api._setForDevice("key", release, handler);
     });
 };
@@ -211,7 +215,7 @@ SoundTouchAPI.prototype.removeZoneSlave = function(members, handler) {
 
 SoundTouchAPI.prototype._zones = function(action, members, handler) {
     var item = {};
-    
+
     // the below line looked like it might have been a copy/paste error from discovery.js? master is undefined here.
     // item.master = master;
     var data = '<zone master="' + this.getDevice().txtRecord.MAC + '" senderIPAddress="127.0.0.1">';
@@ -222,7 +226,7 @@ SoundTouchAPI.prototype._zones = function(action, members, handler) {
             item.slaves = [];
             item.slaves.push(member);
             data += '<member>' + member + '</member>';
-        } else  {
+        } else {
             item.slaves.push(member);
             data += '<member>' + member + '</member>';
         }
@@ -353,10 +357,10 @@ SoundTouchAPI.prototype.setRecentsUpdatedListener = function(handler) {
 };
 
 /*
-****** UTILITY METHODS ***********
+ ****** UTILITY METHODS ***********
  */
 
-SoundTouchAPI.prototype._getForDevice = function (action, callback) {
+SoundTouchAPI.prototype._getForDevice = function(action, callback) {
     var device = this.getMetaData();
     http.get(device.url + "/" + action, function(response) {
             parser.convertResponse(response, function(json) {
@@ -369,10 +373,10 @@ SoundTouchAPI.prototype._getForDevice = function (action, callback) {
         });
 };
 
-SoundTouchAPI.prototype._setForDevice = function (action, data, handler) {
+SoundTouchAPI.prototype._setForDevice = function(action, data, handler) {
     var device = this.getDevice();
 
-    var options =  {
+    var options = {
         url: device.url + '/' + action,
         form: data
     };

--- a/collectorSettingsExample.json
+++ b/collectorSettingsExample.json
@@ -1,0 +1,3 @@
+{
+  "deviceToListen": "YOUR DEVICE NAME"
+}

--- a/episodeCollector.js
+++ b/episodeCollector.js
@@ -6,8 +6,6 @@ var store = require('data-store')('libraryContent', {
     cwd: 'dataStore'
 });
 
-// Your configuration here
-// Default settings
 // Store your setting better in collectorSettings.json
 // start from collectorSettingsExample.json by copying
 var settings = {
@@ -35,6 +33,7 @@ soundTouchDiscovery.search(function(deviceAPI) {
     deviceAPI.setNowPlayingUpdatedListener(function(json) {
         if (deviceAPI.name === settings.deviceToListen) {
             if (json.nowPlaying.ContentItem != undefined) {
+              console.log('We received ', json.nowPlaying.ContentItem);
                 // we do not want to store duplicate items
                 if (!store.has(json.nowPlaying.ContentItem.location)) {
                   var contentItem = json.nowPlaying.ContentItem ;

--- a/episodeCollector.js
+++ b/episodeCollector.js
@@ -1,0 +1,56 @@
+var soundTouchDiscovery = require('./discovery');
+var fs = require('fs');
+var path = require('path');
+var util = require('util');
+var store = require('data-store')('libraryContent', {
+    cwd: 'dataStore'
+});
+
+// Your configuration here
+// Default settings
+// Store your setting better in collectorSettings.json
+// start from collectorSettingsExample.json by copying
+var settings = {
+    deviceToListen: 'Office'
+};
+
+
+// load user settings
+try {
+    var userSettings = require(path.resolve(__dirname, 'collectorSettings.json'));
+} catch (e) {
+    console.log('No collectorSetting.json file found, will only use default settings');
+}
+
+if (userSettings) {
+    for (var i in userSettings) {
+        settings[i] = userSettings[i];
+    }
+}
+console.log("Listening to device: " + settings.deviceToListen);
+console.log(store.get());
+
+soundTouchDiscovery.search(function(deviceAPI) {
+    deviceAPI.socketStart();
+    deviceAPI.setNowPlayingUpdatedListener(function(json) {
+        if (deviceAPI.name === settings.deviceToListen) {
+            if (json.nowPlaying.ContentItem != undefined) {
+                // we do not want to store duplicate items
+                if (!store.has(json.nowPlaying.ContentItem.location)) {
+                  var contentItem = json.nowPlaying.ContentItem ;
+                  // NOTE: Would check for isPresetable, but there are cases where even
+                  // it is not presetable (like AUX) isPresetable is set to true
+                    console.log('Storing location for: ', contentItem.itemName);
+                    store.set(contentItem.location, {
+                        source: contentItem.source,
+                        sourceAccount: contentItem.sourceAccount,
+                        name: contentItem.itemName
+                    });
+                }
+            }
+        }
+
+    });
+
+    soundTouchDiscovery.stopSearching();
+});

--- a/package.json
+++ b/package.json
@@ -1,10 +1,12 @@
 {
   "name": "soundtouch",
   "version": "4.0.1",
-  "description": "Bose SoundTouch node js API",
+  "private": true,
+  "description": "Bose SoundTouch node js API as Theos fork",
   "main": "discovery.js",
   "scripts": {
-    "test": "make test"
+    "test": "make test",
+    "start": "node server.js"
   },
   "author": "CONNCTED",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "mocha": "^3.2.0"
   },
   "dependencies": {
+    "data-store": "^1.0.0",
     "express": "^4.15.2",
     "mdns": "^2.3.3",
     "net": "^1.0.2",

--- a/package/episodeSelector.js
+++ b/package/episodeSelector.js
@@ -1,0 +1,95 @@
+var http = require('http');
+var parser = require('../utils/xmltojson');
+var SOURCE = require('../utils/types').Source;
+var store = require('data-store')('libraryContent', {
+    cwd: 'dataStore'
+});
+
+var util = require('util');
+
+const ALLIDS = store.get();
+const ALLIDS_SIZE = _getStoreLength(ALLIDS);
+var PRESET_KEY_NO = 6;
+
+var originalVolumen;
+
+function _wait(msec) {
+    var waitTill = new Date(new Date().getTime() + msec);
+    while (waitTill > new Date()) {}
+}
+
+function _randomIntInc(low, high) {
+    return Math.floor(Math.random() * (high - low + 1) + low);
+}
+
+function _getStoreLength(store) {
+    var i = 0;
+    for (var j in store) {
+        i++;
+    }
+    return i;
+}
+
+function _getElement(n, store) {
+    var i = 0;
+    for (var j in store) {
+        i++;
+        if (i === n) {
+            return j
+        }
+    }
+}
+
+
+function _storeActualVolume(json) {
+    originalVolumen = json.volume.actualvolume;
+}
+
+function reduceVolume(device, req, res) {
+    device.getVolume(_storeActualVolume);
+    device.setVolume(1, function(json) {})
+}
+
+// TODO: Document this
+// localhost:5006/Kueche/auto/episodeSelector/?presetkey=5
+
+function selectRandomEpisode(device, req, res, location) {
+    var theEpisodeNo = _randomIntInc(1, ALLIDS_SIZE);
+    var theEpisodeElement = _getElement(theEpisodeNo, ALLIDS)
+    var theEpisodeContent = store.get(theEpisodeElement);
+
+    reduceVolume(device, req, res);
+    if (req.query.presetkey != undefined) {
+        PRESET_KEY_NO = req.query.presetkey;
+    }
+    device.select(theEpisodeContent.source, undefined, theEpisodeContent.sourceAccount, theEpisodeElement,
+        function(json) {
+            _wait(1000); // wait a second after started playing
+            device.stop(function() {});
+            device.setPreset(PRESET_KEY_NO,
+                function(json) {
+                    device.stop(function() {
+                      device.setVolume(originalVolumen, function() {});
+                    });
+                }
+            )
+        }
+    );
+    res.json({
+        album: theEpisodeContent.name,
+        entry: theEpisodeElement,
+        source: theEpisodeContent.source,
+        sourceAccount: theEpisodeContent.sourceAccount,
+        presetKey: PRESET_KEY_NO
+    });
+
+}
+
+function getAllEpisodes(discovery, req, res) {
+    res.json(ALLIDS);
+}
+
+module.exports = function(api) {
+    api.registerRestService('/auto/getAllEpisodes', getAllEpisodes)
+    api.registerDeviceRestService('/auto/episodeSelector', selectRandomEpisode);
+};

--- a/package/episodeSelector.js
+++ b/package/episodeSelector.js
@@ -96,11 +96,47 @@ function selectRandomEpisode(device, req, res, location) {
 
 }
 
+function episodeMove(device, req, res, location) {
+    var from = parseInt(req.params.from, 10);
+    var to = parseInt(req.params.to, 10);
+
+    reduceVolume(device, req, res);
+
+    if ((from == to)) {
+        // 416 	Requested range not satisfiable
+        res.status(416).json({
+            message: "from and to should be different"
+        });
+        return;
+    } else if (from < 1 || from > 6 || to < 1 || to > 6) {
+        // 416 	Requested range not satisfiable
+        res.status(416).json({
+            message: "from and/or to preset should be between 1 and 6"
+        });
+        return;
+
+    }
+
+    // start playing _old
+    var _fromKey = "PRESET_" + from;
+
+    device.pressKey(_fromKey, function() {
+        device.stop(function() {});
+        device.setPreset(to, function() {});
+        _wait(1000);
+        res.json({
+            from: from,
+            to: to
+        });
+    });
+}
+
 function getAllEpisodes(discovery, req, res) {
     res.json(ALLIDS);
 }
 
 module.exports = function(api) {
-    api.registerRestService('/auto/getAllEpisodes', getAllEpisodes)
+    api.registerRestService('/auto/getAllEpisodes', getAllEpisodes);
     api.registerDeviceRestService('/auto/episodeSelector/:presetKey?', selectRandomEpisode);
+    api.registerDeviceRestService('/auto/episodeMove/:from/:to', episodeMove);
 };

--- a/package/smart_zones.js
+++ b/package/smart_zones.js
@@ -71,11 +71,11 @@ function _processNowPlayingList(discovery, req, res) {
 }
 
 function _isValidSource(source) {
-   return (source == SOURCE.INTERNET_RADIO
-       || source == SOURCE.PANDORA
+   return (source == SOURCE.PANDORA
        || source == SOURCE.DEEZER
        || source == SOURCE.IHEART
        || source == SOURCE.SPOTIFY
+       || source == SOURCE.TUNEIN
    );
 }
 

--- a/utils/types.js
+++ b/utils/types.js
@@ -1,7 +1,6 @@
 module.exports = {
     Source: {
         SLAVE_SOURCE: "SLAVE_SOURCE",
-        INTERNET_RADIO: "INTERNET_RADIO",
         PANDORA: "PANDORA",
         AIRPLAY: "AIRPLAY",
         STORED_MUSIC: "STORED_MUSIC",
@@ -12,7 +11,8 @@ module.exports = {
         UPDATE: "UPDATE",
         DEEZER: "DEEZER",
         SPOTIFY: "SPOTIFY",
-        IHEART: "IHEART"
+        IHEART: "IHEART",
+        TUNEIN: "TUNEIN"
     },
     Keys: {
         PLAY: "PLAY",


### PR DESCRIPTION
added a new functionality called episode selector. 

# Motivation
It is not so uncommon that you would like to randomly select a content from your soundtouch location. In our household, the kids have a demand to have on a specific preset a regularly changing audio book available, but without having to take a computer, phone or tablet into their hands. Other application areas could be to rotate through a list of internet radio stations. 

# Requirement 1
In order to store a content on a given preset we must be able to reference the content. Soundtouch uses a combination of source, sourceAccount and location information to reference this information.  We are using a music libary on a NAS. From this content there is a relatively small amount of content that we want to select from. In our case some 200 episodes. Therefore you should be able to create this pool of content with the information required by the SoundTouch system. For this I created the `episodeCollector.js` script. 

Usage

     node episodeCollector.js

Will start a service that listens to update from a specific device as named in `collectorSettings.json`. 
Select the named device in your SoundTouch-app and select a new content. This content will be added to`data-store/libraryContent.json`. The file will be created if not existent.  Select all content in the SoundTouch-App one by one that  you would like to add to the libaryContent. If selecting the same content multple times, only one reference will be created in `libraryContent`.

# Requirement 2
We need a functionality where we can trigger an action that 
 * randomly selects one content from `libraryContent` and 
 * stores it at a given preset, if given or the default one, if none is provided

Because of the limitations of the SoundTouch-API it is not possible to store a content directly for a preset. Therefore we introduced the following REST-call

    /:deviceName/auto/episodeSelector/:presetKey?

In order to program a preset we 
 * select a device
 * start playing the desired content
 * pushing and holding the preset key for around a second
 * releasing the key
 * stopping the playback of the content

Just to make it a little bit safe, we reduce the volume on the device and restore the original volume afterwards. 

The function returns a JSON object of the following format: 
```json
{
    "album": "035 Und Der Hoehlenmensch",
    "entry": "0$1$18$3340$19925$20556",
    "source": "STORED_MUSIC",
    "sourceAccount": "55076f6e-6b79-1d65-a4eb-00089bea8bd7/0",
    "presetKey": 6
}
```
or 
`416 - Range not satisfied` error code with 
```
{
    "message": "presetKey should be between 1 and 6"
}
```

# Requirement 3
After a while we did not know exactly what content is stored in the libraryContent.  Therefore we introduced a REST-call 

     /auto/getAllEpisodes

which returns a list of all episodes as a json object of the format: 
```json
{
    "0$1$18$3340$19925$21162": {
        "source": "STORED_MUSIC",
        "sourceAccount": "55076f6e-6b79-1d65-a4eb-00089bea8bd7/0",
        "name": "001 - Und der Super Papagei"
    },
```

# Final remarks
As a result we have been able to create a small framework to have some content available for selection as preset. By exposing this functionality via a REST-API we are able to regularly change the content of presets for example via a cron-job or similar. 

As I believe this could be usefull for other too, I propose this pull request. It should be automatically mergeable 

# Tested with
I tested this with Soundtouch system consisting of 6 Boses, stored media and internet radio presets.

## NOTE
In order to programm a preset we have a push and HOLD the key for a while. A small extension was required in api.js
